### PR TITLE
Clippy says to prefer From over Into

### DIFF
--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -62,10 +62,10 @@ enum Method {
     Patch,
 }
 
-impl Into<reqwest::Method> for Method {
-    fn into(self) -> reqwest::Method {
+impl From<Method> for reqwest::Method {
+    fn from(method: Method) -> Self {
         use Method::*;
-        match self {
+        match method {
             Options => reqwest::Method::OPTIONS,
             Get => reqwest::Method::GET,
             Post => reqwest::Method::POST,


### PR DESCRIPTION
Great project! If you're keen to accept PRs then I thought I'd start by running clippy over the code. This fixes

```
warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
```