### PR TITLE
handle runtime failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Usage
 ### Start a client
 
 ``` erlang
+ok = application:ensure_started(erqwest),
 ok = erqwest:start_client(default).
 ```
 
@@ -42,7 +43,8 @@ internal connection pool.
 ### Asynchronous interface
 
 ``` erlang
-ok = erqwest:req_async(default, self(), Ref=make_ref(), #{method => get, url => <<"https://httpbin.org/get">>}).
+erqwest:req_async(default, self(), Ref=make_ref(), 
+                  #{method => get, url => <<"https://httpbin.org/get">>}),
 receive
     {erqwest_response, Ref, {ok, #{status := 200}}} -> ok
 end.
@@ -53,9 +55,3 @@ end.
 
 [Benchmarks](bench)
 -------------------
-
-Todo
-----
-
-* Shut down tokio event loop cleanly
-* Test thoroughly

--- a/native/src/client.rs
+++ b/native/src/client.rs
@@ -1,0 +1,143 @@
+use std::sync::RwLock;
+
+use reqwest::{Certificate, Identity};
+use rustler::{Atom, Encoder, Env, NifMap, NifResult, NifUnitEnum, ResourceArc, Term};
+use rustler::{Binary, ListIterator};
+
+use crate::timeout::maybe_timeout;
+use crate::{atoms, runtime::RuntimeResource};
+
+#[derive(NifUnitEnum)]
+enum Proxy {
+    System,
+    NoProxy,
+}
+
+#[derive(NifUnitEnum)]
+enum ProxyType {
+    Http,
+    Https,
+    All,
+}
+
+#[derive(NifMap)]
+struct ProxySpecBase {
+    url: String,
+}
+
+pub struct ClientResource {
+    pub client: RwLock<Option<reqwest::Client>>,
+    pub runtime: ResourceArc<RuntimeResource>,
+}
+
+#[rustler::nif]
+fn make_client(
+    env: Env,
+    runtime: ResourceArc<RuntimeResource>,
+    opts: Term,
+) -> NifResult<ResourceArc<ClientResource>> {
+    let _ = env;
+    if !opts.is_map() || runtime.is_closed() {
+        return Err(rustler::Error::BadArg);
+    }
+    let mut builder = reqwest::ClientBuilder::new();
+    if let Ok(term) = opts.map_get(atoms::identity().encode(env)) {
+        let (pkcs12, pass): (Binary, String) = term.decode()?;
+        builder = builder.identity(
+            Identity::from_pkcs12_der(pkcs12.as_slice(), &pass)
+                .map_err(|_| rustler::Error::BadArg)?,
+        );
+    };
+    if let Ok(term) = opts.map_get(atoms::use_built_in_root_certs().encode(env)) {
+        builder = builder.tls_built_in_root_certs(term.decode()?);
+    };
+    if let Ok(term) = opts.map_get(atoms::additional_root_certs().encode(env)) {
+        for cert in term.decode::<ListIterator>()? {
+            let cert_bin: Binary = cert.decode()?;
+            builder = builder.add_root_certificate(
+                Certificate::from_der(cert_bin.as_slice()).map_err(|_| rustler::Error::BadArg)?,
+            );
+        }
+    };
+    if let Ok(term) = opts.map_get(atoms::follow_redirects().encode(env)) {
+        let policy = match term.decode::<bool>() {
+            Ok(true) => Ok(reqwest::redirect::Policy::default()),
+            Ok(false) => Ok(reqwest::redirect::Policy::none()),
+            Err(_) => match term.decode::<usize>() {
+                Ok(n) => Ok(reqwest::redirect::Policy::limited(n)),
+                Err(_) => Err(rustler::Error::BadArg),
+            },
+        }?;
+        builder = builder.redirect(policy);
+    };
+    if let Ok(term) = opts.map_get(atoms::danger_accept_invalid_hostnames().encode(env)) {
+        builder = builder.danger_accept_invalid_hostnames(term.decode()?);
+    };
+    if let Ok(term) = opts.map_get(atoms::danger_accept_invalid_certs().encode(env)) {
+        builder = builder.danger_accept_invalid_certs(term.decode()?);
+    };
+    if let Ok(term) = opts.map_get(atoms::connect_timeout().encode(env)) {
+        if let Some(timeout) = maybe_timeout(term)? {
+            builder = builder.connect_timeout(timeout);
+        }
+    };
+    if let Ok(term) = opts.map_get(atoms::timeout().encode(env)) {
+        if let Some(timeout) = maybe_timeout(term)? {
+            builder = builder.timeout(timeout);
+        }
+    };
+    if let Ok(term) = opts.map_get(atoms::pool_idle_timeout().encode(env)) {
+        builder = builder.pool_idle_timeout(maybe_timeout(term)?);
+    };
+    if let Ok(term) = opts.map_get(atoms::pool_max_idle_per_host().encode(env)) {
+        builder = builder.pool_max_idle_per_host(term.decode()?);
+    };
+    if let Ok(term) = opts.map_get(atoms::https_only().encode(env)) {
+        builder = builder.https_only(term.decode()?);
+    };
+    if let Ok(term) = opts.map_get(atoms::cookie_store().encode(env)) {
+        builder = builder.cookie_store(term.decode()?);
+    };
+    if let Ok(term) = opts.map_get(atoms::proxy().encode(env)) {
+        match term.decode::<Proxy>() {
+            Ok(Proxy::System) => (),
+            Ok(Proxy::NoProxy) => {
+                builder = builder.no_proxy();
+            }
+            Err(_) => {
+                for proxy in term.decode::<ListIterator>()? {
+                    let (proxy_type, proxy_spec): (ProxyType, Term) = proxy.decode()?;
+                    let ProxySpecBase { url } = proxy_spec.decode()?;
+                    let mut proxy = match proxy_type {
+                        ProxyType::Http => reqwest::Proxy::http(url),
+                        ProxyType::Https => reqwest::Proxy::https(url),
+                        ProxyType::All => reqwest::Proxy::all(url),
+                    }
+                    .map_err(|_| rustler::Error::BadArg)?;
+                    if let Ok(term) = proxy_spec.map_get(atoms::basic_auth().encode(env)) {
+                        let (username, password) = term.decode()?;
+                        proxy = proxy.basic_auth(username, password);
+                    }
+                    builder = builder.proxy(proxy);
+                }
+            }
+        }
+    };
+    let client = builder.build().map_err(|e| {
+        rustler::Error::RaiseTerm(Box::new((atoms::client_builder_error(), e.to_string())))
+    })?;
+    Ok(ResourceArc::new(ClientResource {
+        client: RwLock::new(Some(client)),
+        runtime,
+    }))
+}
+
+#[rustler::nif]
+fn close_client(resource: ResourceArc<ClientResource>) -> NifResult<Atom> {
+    if resource.client.write().unwrap().take().is_some() {
+        Ok(atoms::ok())
+    } else {
+        // already closed
+        Err(rustler::Error::BadArg)
+    }
+}

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -1,14 +1,9 @@
-use reqwest::{Certificate, Identity};
-use rustler::types::map;
-use rustler::{Atom, Binary, Encoder, Env, ListIterator, LocalPid, NifResult, OwnedBinary, Term};
-use rustler::env::SavedTerm;
-use rustler::{NifMap, NifUnitEnum, NifUntaggedEnum, OwnedEnv, ResourceArc};
-use futures::future::{Abortable, AbortHandle};
-use std::io::Write;
-use std::sync::RwLock;
-use std::thread;
-use std::time::Duration;
-use tokio::runtime::{Handle, Runtime};
+use rustler::{Env, Term};
+
+mod client;
+mod req;
+mod runtime;
+mod timeout;
 
 mod atoms {
     rustler::atoms! {
@@ -18,9 +13,11 @@ mod atoms {
         body,
         connect_timeout,
         cookie_store,
+        client_builder_error,
         danger_accept_invalid_certs,
         danger_accept_invalid_hostnames,
         erqwest_response,
+        erqwest_runtime_stopped,
         error,
         follow_redirects,
         headers,
@@ -39,375 +36,22 @@ mod atoms {
     }
 }
 
-#[derive(NifUnitEnum)]
-enum Infinity {
-    Infinity
-}
-
-#[derive(NifUntaggedEnum)]
-enum Timeout {
-    Infinity(Infinity),
-    Timeout(u64)
-}
-
-#[derive(NifUnitEnum)]
-enum Proxy {
-    System,
-    NoProxy,
-}
-
-#[derive(NifUnitEnum)]
-enum ProxyType {
-    Http,
-    Https,
-    All,
-}
-
-#[derive(NifMap)]
-struct ProxySpecBase {
-    url: String,
-}
-
-#[derive(NifUnitEnum, Clone, Copy, Debug)]
-enum Method {
-    Options,
-    Get,
-    Post,
-    Put,
-    Delete,
-    Head,
-    Trace,
-    Connect,
-    Patch,
-}
-
-impl From<Method> for reqwest::Method {
-    fn from(method: Method) -> Self {
-        use Method::*;
-        match method {
-            Options => reqwest::Method::OPTIONS,
-            Get => reqwest::Method::GET,
-            Post => reqwest::Method::POST,
-            Put => reqwest::Method::PUT,
-            Delete => reqwest::Method::DELETE,
-            Head => reqwest::Method::HEAD,
-            Trace => reqwest::Method::TRACE,
-            Connect => reqwest::Method::CONNECT,
-            Patch => reqwest::Method::PATCH,
-        }
-    }
-}
-
-#[derive(NifMap)]
-struct ReqBase {
-    url: String,
-    method: Method,
-}
-
-#[derive(NifUnitEnum)]
-enum ErrorCode {
-    Cancelled,
-    Request,
-    Redirect,
-    Connect,
-    Timeout,
-    Body,
-    Unknown,
-}
-
-#[derive(NifMap)]
-struct Error {
-    code: ErrorCode,
-    reason: String,
-}
-
-impl Error {
-    fn unknown(reason: impl Into<String>) -> Error {
-        Error {
-            code: ErrorCode::Unknown,
-            reason: reason.into(),
-        }
-    }
-}
-
-impl From<reqwest::Error> for Error {
-    fn from(e: reqwest::Error) -> Error {
-        use ErrorCode::*;
-        let code = if e.is_timeout() {
-            Timeout
-        } else if e.is_redirect() {
-            Redirect
-        } else if e.is_connect() {
-            Connect
-        } else if e.is_request() {
-            Request
-        } else if e.is_body() {
-            Body
-        } else {
-            Unknown
-        };
-        let reason = e.to_string();
-        Error { code, reason }
-    }
-}
-
-struct ErqwestResponse {
-    env: Option<OwnedEnv>,
-    caller_ref: SavedTerm,
-    caller_pid: LocalPid
-}
-
-impl ErqwestResponse {
-    pub fn new(caller_ref: Term, caller_pid: LocalPid) -> ErqwestResponse {
-        let env = OwnedEnv::new();
-        let caller_ref = env.save(caller_ref);
-        ErqwestResponse { env: Some(env), caller_ref, caller_pid }
-    }
-    fn send(&mut self, res: Result<(u16, Vec<(String, OwnedBinary)>, OwnedBinary), Error>) {
-        self.env.take().unwrap().send_and_clear(&self.caller_pid, |env| {
-            let res = res.and_then(|r| {
-                encode_resp(env, r).map_err(|_| Error::unknown("failed encoding result"))
-            });
-            let res = match res {
-                Ok(term) => (atoms::ok(), term).encode(env),
-                Err(e) => env.error_tuple(e),
-            };
-            let caller_ref = self.caller_ref.load(env);
-            (atoms::erqwest_response(), caller_ref, res).encode(env)
-        });
-    }
-}
-
-impl Drop for ErqwestResponse {
-    fn drop(&mut self) {
-        if self.env.is_some() {
-            self.send(Err(Error { code: ErrorCode::Cancelled, reason: "future dropped".into() }));
-        }
-    }
-}
-
-lazy_static::lazy_static! {
-    static ref HANDLE: Handle = {
-        let (handle_tx, handle_rx) = std::sync::mpsc::channel();
-        thread::spawn(move || {
-            let runtime = Runtime::new().unwrap();
-            handle_tx.send(runtime.handle().clone()).unwrap();
-            runtime.block_on(std::future::pending::<()>());
-        });
-        handle_rx.recv().unwrap()
-    };
-}
-
-struct ClientResource(RwLock<Option<reqwest::Client>>);
-
-struct AbortResource(AbortHandle);
-
-#[rustler::nif]
-fn make_client(env: Env, opts: Term) -> NifResult<ResourceArc<ClientResource>> {
-    let _ = env;
-    if !opts.is_map() {
-        return Err(rustler::Error::BadArg);
-    }
-    let mut builder = reqwest::ClientBuilder::new();
-    if let Ok(term) = opts.map_get(atoms::identity().encode(env)) {
-        let (pkcs12, pass): (Binary, String) = term.decode()?;
-        builder = builder.identity(
-            Identity::from_pkcs12_der(pkcs12.as_slice(), &pass)
-                .map_err(|_| rustler::Error::BadArg)?,
-        );
-    };
-    if let Ok(term) = opts.map_get(atoms::use_built_in_root_certs().encode(env)) {
-        builder = builder.tls_built_in_root_certs(term.decode()?);
-    };
-    if let Ok(term) = opts.map_get(atoms::additional_root_certs().encode(env)) {
-        for cert in term.decode::<ListIterator>()? {
-            let cert_bin: Binary = cert.decode()?;
-            builder = builder.add_root_certificate(
-                Certificate::from_der(cert_bin.as_slice()).map_err(|_| rustler::Error::BadArg)?,
-            );
-        }
-    };
-    if let Ok(term) = opts.map_get(atoms::follow_redirects().encode(env)) {
-        let policy = match term.decode::<bool>() {
-            Ok(true) => Ok(reqwest::redirect::Policy::default()),
-            Ok(false) => Ok(reqwest::redirect::Policy::none()),
-            Err(_) => match term.decode::<usize>() {
-                Ok(n) => Ok(reqwest::redirect::Policy::limited(n)),
-                Err(_) => Err(rustler::Error::BadArg),
-            },
-        }?;
-        builder = builder.redirect(policy);
-    };
-    if let Ok(term) = opts.map_get(atoms::danger_accept_invalid_hostnames().encode(env)) {
-        builder = builder.danger_accept_invalid_hostnames(term.decode()?);
-    };
-    if let Ok(term) = opts.map_get(atoms::danger_accept_invalid_certs().encode(env)) {
-        builder = builder.danger_accept_invalid_certs(term.decode()?);
-    };
-    if let Ok(term) = opts.map_get(atoms::connect_timeout().encode(env)) {
-        if let Some(timeout) = maybe_timeout(term.decode()?) {
-            builder = builder.connect_timeout(timeout);
-        }
-    };
-    if let Ok(term) = opts.map_get(atoms::timeout().encode(env)) {
-        if let Some(timeout) = maybe_timeout(term.decode()?) {
-            builder = builder.timeout(timeout);
-        }
-    };
-    if let Ok(term) = opts.map_get(atoms::pool_idle_timeout().encode(env)) {
-        builder = builder.pool_idle_timeout(maybe_timeout(term.decode()?));
-    };
-    if let Ok(term) = opts.map_get(atoms::pool_max_idle_per_host().encode(env)) {
-        builder = builder.pool_max_idle_per_host(term.decode()?);
-    };
-    if let Ok(term) = opts.map_get(atoms::https_only().encode(env)) {
-        builder = builder.https_only(term.decode()?);
-    }
-    if let Ok(term) = opts.map_get(atoms::cookie_store().encode(env)) {
-        builder = builder.cookie_store(term.decode()?);
-    };
-    if let Ok(term) = opts.map_get(atoms::proxy().encode(env)) {
-        match term.decode::<Proxy>() {
-            Ok(Proxy::System) => (),
-            Ok(Proxy::NoProxy) => {
-                builder = builder.no_proxy();
-            }
-            Err(_) => {
-                for proxy in term.decode::<ListIterator>()? {
-                    let (proxy_type, proxy_spec): (ProxyType, Term) = proxy.decode()?;
-                    let ProxySpecBase { url } = proxy_spec.decode()?;
-                    let mut proxy = match proxy_type {
-                        ProxyType::Http => reqwest::Proxy::http(url),
-                        ProxyType::Https => reqwest::Proxy::https(url),
-                        ProxyType::All => reqwest::Proxy::all(url),
-                    }
-                    .map_err(|_| rustler::Error::BadArg)?;
-                    if let Ok(term) = proxy_spec.map_get(atoms::basic_auth().encode(env)) {
-                        let (username, password) = term.decode()?;
-                        proxy = proxy.basic_auth(username, password);
-                    }
-                    builder = builder.proxy(proxy);
-                }
-            }
-        }
-    };
-    let client = builder
-        .build()
-        .map_err(|e| rustler::Error::RaiseTerm(Box::new(Error::unknown(e.to_string()))))?;
-    Ok(ResourceArc::new(ClientResource(RwLock::new(Some(client)))))
-}
-
-#[rustler::nif]
-fn close_client(resource: ResourceArc<ClientResource>) -> NifResult<Atom> {
-    if resource.0.write().unwrap().take().is_some() {
-        Ok(atoms::ok())
-    } else {
-        // already closed
-        Err(rustler::Error::BadArg)
-    }
-}
-
-#[rustler::nif]
-fn req_async_internal(
-    resource: ResourceArc<ClientResource>,
-    pid: LocalPid,
-    caller_ref: Term,
-    req: Term,
-) -> NifResult<ResourceArc<AbortResource>> {
-    let env = req.get_env();
-    let ReqBase { url, method } = req.decode()?;
-    // returns BadArg if the client was already closed with close_client
-    let client = resource
-        .0
-        .read()
-        .unwrap()
-        .as_ref()
-        .ok_or(rustler::Error::BadArg)?
-        .clone();
-    let mut req_builder = client.request(method.into(), url);
-    if let Ok(term) = req.map_get(atoms::headers().encode(env)) {
-        for h in term.decode::<ListIterator>()? {
-            let (k, v): (&str, &str) = h.decode()?;
-            req_builder = req_builder.header(k, v);
-        }
-    };
-    if let Ok(term) = req.map_get(atoms::body().encode(env)) {
-        req_builder = req_builder.body(term.decode::<Binary>()?.as_slice().to_owned());
-    };
-    if let Ok(term) = req.map_get(atoms::timeout().encode(env)) {
-        if let Some(timeout) = maybe_timeout(term.decode()?) {
-            req_builder = req_builder.timeout(timeout);
-        }
-    };
-    let mut response = ErqwestResponse::new(caller_ref, pid);
-    let fut = async move {
-        let resp = do_req(req_builder).await;
-        response.send(resp);
-    };
-    let (abort_handle, abort_registration) = AbortHandle::new_pair();
-    HANDLE.spawn(Abortable::new(fut, abort_registration));
-    Ok(ResourceArc::new(AbortResource(abort_handle)))
-}
-
-async fn do_req(
-    req: reqwest::RequestBuilder,
-) -> Result<(u16, Vec<(String, OwnedBinary)>, OwnedBinary), Error> {
-    let resp = req.send().await?;
-    let status = resp.status().as_u16();
-    // Do we need to handle this or would unwrap do?
-    let allocation_failed = || Error {
-        code: ErrorCode::Unknown,
-        reason: "binary allocation failed".into(),
-    };
-    let mut headers = Vec::with_capacity(resp.headers().len());
-    for (k, v) in resp.headers().iter() {
-        let mut v1 = OwnedBinary::new(v.as_bytes().len()).ok_or_else(allocation_failed)?;
-        v1.as_mut_slice().write_all(v.as_bytes()).unwrap();
-        headers.push((k.as_str().into(), v1))
-    }
-    let bytes = resp.bytes().await?;
-    let mut body = OwnedBinary::new(bytes.len()).ok_or_else(allocation_failed)?;
-    body.as_mut_slice().write_all(&bytes).unwrap();
-    Ok((status, headers, body))
-}
-
-fn encode_resp(
-    env: Env,
-    (status, headers, body): (u16, Vec<(String, OwnedBinary)>, OwnedBinary),
-) -> NifResult<Term> {
-    let headers1: Vec<_> = headers
-        .into_iter()
-        .map(|(k, v)| (k, v.release(env)))
-        .collect();
-    let mut map = map::map_new(env);
-    map = map.map_put(atoms::status().encode(env), status.encode(env))?;
-    map = map.map_put(atoms::headers().encode(env), headers1.encode(env))?;
-    map = map.map_put(atoms::body().encode(env), body.release(env).encode(env))?;
-    Ok(map.encode(env))
-}
-
-#[rustler::nif]
-fn cancel(abort_handle: ResourceArc<AbortResource>) -> NifResult<Atom> {
-    abort_handle.0.abort();
-    Ok(atoms::ok())
-}
-
-fn maybe_timeout(t: Timeout) -> Option<Duration> {
-    match t {
-        Timeout::Infinity(_) => None,
-        Timeout::Timeout(ms) => Some(Duration::from_millis(ms))
-    }
-}
-
 fn load(env: Env, _info: Term) -> bool {
-    lazy_static::initialize(&HANDLE);
-    rustler::resource!(ClientResource, env);
-    rustler::resource!(AbortResource, env);
+    rustler::resource!(client::ClientResource, env);
+    rustler::resource!(req::AbortResource, env);
+    rustler::resource!(runtime::RuntimeResource, env);
     true
 }
 
 rustler::init!(
     "erqwest",
-    [make_client, close_client, req_async_internal, cancel],
+    [
+        runtime::start_runtime,
+        runtime::stop_runtime,
+        client::make_client,
+        client::close_client,
+        req::req_async_internal,
+        req::cancel
+    ],
     load = load
 );

--- a/native/src/req.rs
+++ b/native/src/req.rs
@@ -1,0 +1,248 @@
+use futures::future::{AbortHandle, Abortable};
+use rustler::env::SavedTerm;
+use rustler::types::map;
+use rustler::{Atom, Binary, Encoder, Env, ListIterator, LocalPid, NifResult, OwnedBinary, Term};
+use rustler::{NifMap, NifUnitEnum, OwnedEnv, ResourceArc};
+use std::borrow::BorrowMut;
+use std::io::Write;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread::{self, ThreadId};
+
+use crate::atoms;
+use crate::client::ClientResource;
+use crate::timeout::maybe_timeout;
+
+#[derive(NifUnitEnum, Clone, Copy, Debug)]
+enum Method {
+    Options,
+    Get,
+    Post,
+    Put,
+    Delete,
+    Head,
+    Trace,
+    Connect,
+    Patch,
+}
+
+impl From<Method> for reqwest::Method {
+    fn from(method: Method) -> Self {
+        use Method::*;
+        match method {
+            Options => reqwest::Method::OPTIONS,
+            Get => reqwest::Method::GET,
+            Post => reqwest::Method::POST,
+            Put => reqwest::Method::PUT,
+            Delete => reqwest::Method::DELETE,
+            Head => reqwest::Method::HEAD,
+            Trace => reqwest::Method::TRACE,
+            Connect => reqwest::Method::CONNECT,
+            Patch => reqwest::Method::PATCH,
+        }
+    }
+}
+
+#[derive(NifMap)]
+struct ReqBase {
+    url: String,
+    method: Method,
+}
+
+#[derive(NifUnitEnum)]
+enum ErrorCode {
+    Cancelled,
+    Request,
+    Redirect,
+    Connect,
+    Timeout,
+    Body,
+    Unknown,
+}
+
+#[derive(NifMap)]
+struct Error {
+    code: ErrorCode,
+    reason: String,
+}
+
+impl Error {
+    fn unknown(reason: impl Into<String>) -> Error {
+        Error {
+            code: ErrorCode::Unknown,
+            reason: reason.into(),
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(e: reqwest::Error) -> Error {
+        use ErrorCode::*;
+        let code = if e.is_timeout() {
+            Timeout
+        } else if e.is_redirect() {
+            Redirect
+        } else if e.is_connect() {
+            Connect
+        } else if e.is_request() {
+            Request
+        } else if e.is_body() {
+            Body
+        } else {
+            Unknown
+        };
+        let reason = e.to_string();
+        Error { code, reason }
+    }
+}
+
+struct ErqwestResponse {
+    env: Option<OwnedEnv>,
+    caller_ref: SavedTerm,
+    caller_pid: LocalPid,
+    initial_thread: ThreadId,
+    dropped_on_initial_thread: Arc<AtomicBool>,
+}
+
+impl ErqwestResponse {
+    pub fn new(caller_ref: Term, caller_pid: LocalPid) -> ErqwestResponse {
+        let env = OwnedEnv::new();
+        let caller_ref = env.save(caller_ref);
+        ErqwestResponse {
+            env: Some(env),
+            caller_ref,
+            caller_pid,
+            initial_thread: thread::current().id(),
+            dropped_on_initial_thread: Arc::new(AtomicBool::new(false)),
+        }
+    }
+    fn send(&mut self, res: Result<(u16, Vec<(String, OwnedBinary)>, OwnedBinary), Error>) {
+        self.env
+            .take()
+            .unwrap()
+            .send_and_clear(&self.caller_pid, |env| {
+                let res = res.and_then(|r| {
+                    encode_resp(env, r).map_err(|_| Error::unknown("failed encoding result"))
+                });
+                let res = match res {
+                    Ok(term) => (atoms::ok(), term).encode(env),
+                    Err(e) => env.error_tuple(e),
+                };
+                let caller_ref = self.caller_ref.load(env);
+                (atoms::erqwest_response(), caller_ref, res).encode(env)
+            });
+    }
+}
+
+impl Drop for ErqwestResponse {
+    fn drop(&mut self) {
+        if self.env.is_some() {
+            if thread::current().id() == self.initial_thread {
+                // We are still on the initial thread, which means the future
+                // was not spawned. We can't send a message from this thread
+                // (managed by the VM) so we set this flag and
+                // `req_async_internal` returns BadArg.
+                self.dropped_on_initial_thread
+                    .borrow_mut()
+                    .store(true, Ordering::Relaxed);
+            } else {
+                self.send(Err(Error {
+                    code: ErrorCode::Cancelled,
+                    reason: "future dropped".into(),
+                }));
+            }
+        }
+    }
+}
+
+pub struct AbortResource(AbortHandle);
+
+#[rustler::nif]
+fn req_async_internal(
+    env: Env,
+    resource: ResourceArc<ClientResource>,
+    pid: LocalPid,
+    caller_ref: Term,
+    req: Term,
+) -> NifResult<ResourceArc<AbortResource>> {
+    let ReqBase { url, method } = req.decode()?;
+    // returns BadArg if the client was already closed with close_client
+    let client = resource
+        .client
+        .read()
+        .unwrap()
+        .as_ref()
+        .ok_or(rustler::Error::BadArg)?
+        .clone();
+    let mut req_builder = client.request(method.into(), url);
+    if let Ok(term) = req.map_get(atoms::headers().encode(env)) {
+        for h in term.decode::<ListIterator>()? {
+            let (k, v): (&str, &str) = h.decode()?;
+            req_builder = req_builder.header(k, v);
+        }
+    };
+    if let Ok(term) = req.map_get(atoms::body().encode(env)) {
+        req_builder = req_builder.body(term.decode::<Binary>()?.as_slice().to_owned());
+    };
+    if let Ok(term) = req.map_get(atoms::timeout().encode(env)) {
+        if let Some(timeout) = maybe_timeout(term)? {
+            req_builder = req_builder.timeout(timeout);
+        }
+    };
+    let mut response = ErqwestResponse::new(caller_ref, pid);
+    // This allows us to detect if the future was immediately dropped (ie. not
+    // sent to another thread), which indicates that the Runtime is shutting
+    // down or has shut down.
+    let dropped_on_initial_thread = response.dropped_on_initial_thread.clone();
+    let fut = async move {
+        let resp = do_req(req_builder).await;
+        response.send(resp);
+    };
+    let (abort_handle, abort_registration) = AbortHandle::new_pair();
+    resource
+        .runtime
+        .spawn(Abortable::new(fut, abort_registration));
+    if dropped_on_initial_thread.load(Ordering::Relaxed) {
+        Err(rustler::Error::RaiseAtom("bad_runtime"))
+    } else {
+        Ok(ResourceArc::new(AbortResource(abort_handle)))
+    }
+}
+
+async fn do_req(
+    req: reqwest::RequestBuilder,
+) -> Result<(u16, Vec<(String, OwnedBinary)>, OwnedBinary), Error> {
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+    let mut headers = Vec::with_capacity(resp.headers().len());
+    for (k, v) in resp.headers().iter() {
+        let mut v1 = OwnedBinary::new(v.as_bytes().len()).unwrap();
+        v1.as_mut_slice().write_all(v.as_bytes()).unwrap();
+        headers.push((k.as_str().into(), v1))
+    }
+    let bytes = resp.bytes().await?;
+    let mut body = OwnedBinary::new(bytes.len()).unwrap();
+    body.as_mut_slice().write_all(&bytes).unwrap();
+    Ok((status, headers, body))
+}
+
+fn encode_resp(
+    env: Env,
+    (status, headers, body): (u16, Vec<(String, OwnedBinary)>, OwnedBinary),
+) -> NifResult<Term> {
+    let headers1: Vec<_> = headers
+        .into_iter()
+        .map(|(k, v)| (k, v.release(env)))
+        .collect();
+    let mut map = map::map_new(env);
+    map = map.map_put(atoms::status().encode(env), status.encode(env))?;
+    map = map.map_put(atoms::headers().encode(env), headers1.encode(env))?;
+    map = map.map_put(atoms::body().encode(env), body.release(env).encode(env))?;
+    Ok(map.encode(env))
+}
+
+#[rustler::nif]
+fn cancel(abort_handle: ResourceArc<AbortResource>) -> NifResult<Atom> {
+    abort_handle.0.abort();
+    Ok(atoms::ok())
+}

--- a/native/src/runtime.rs
+++ b/native/src/runtime.rs
@@ -1,0 +1,69 @@
+use std::{marker::Send, sync::RwLock};
+
+use rustler::{Atom, Encoder, LocalPid, NifResult, OwnedEnv, ResourceArc};
+use std::future::Future;
+use tokio::runtime::Handle;
+
+use crate::atoms;
+
+pub struct RuntimeResource {
+    handle: Handle,
+    shutdown_tx: RwLock<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl RuntimeResource {
+    pub fn spawn(&self, future: impl Future<Output = impl Send + 'static> + Send + 'static) {
+        self.handle.spawn(future);
+    }
+    pub fn is_closed(&self) -> bool {
+        self.shutdown_tx.read().unwrap().is_none()
+    }
+}
+
+impl Drop for RuntimeResource {
+    fn drop(&mut self) {
+        if let Some(shutdown_tx) = self.shutdown_tx.get_mut().unwrap().take() {
+            shutdown_tx.send(()).unwrap();
+        }
+    }
+}
+
+struct Monitor {
+    pid: LocalPid,
+}
+
+impl Drop for Monitor {
+    fn drop(&mut self) {
+        OwnedEnv::new().send_and_clear(&self.pid, |env| {
+            atoms::erqwest_runtime_stopped().encode(env)
+        });
+    }
+}
+
+#[rustler::nif]
+fn start_runtime(monitor_pid: LocalPid) -> ResourceArc<RuntimeResource> {
+    let monitor = Monitor { pid: monitor_pid };
+    let (handle_tx, handle_rx) = std::sync::mpsc::channel();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        handle_tx.send(runtime.handle().clone()).unwrap();
+        runtime.block_on(shutdown_rx).unwrap();
+        drop(monitor);
+    });
+    let handle = handle_rx.recv().unwrap();
+    ResourceArc::new(RuntimeResource {
+        handle,
+        shutdown_tx: RwLock::new(Some(shutdown_tx)),
+    })
+}
+
+#[rustler::nif]
+fn stop_runtime(runtime: ResourceArc<RuntimeResource>) -> NifResult<Atom> {
+    if let Some(shutdown_tx) = runtime.shutdown_tx.write().unwrap().take() {
+        shutdown_tx.send(()).unwrap();
+        Ok(crate::atoms::ok())
+    } else {
+        Err(rustler::Error::BadArg)
+    }
+}

--- a/native/src/timeout.rs
+++ b/native/src/timeout.rs
@@ -1,0 +1,21 @@
+use std::time::Duration;
+
+use rustler::{NifResult, NifUnitEnum, NifUntaggedEnum, Term};
+
+#[derive(NifUnitEnum)]
+enum Infinity {
+    Infinity,
+}
+
+#[derive(NifUntaggedEnum)]
+enum Timeout {
+    Infinity(Infinity),
+    Timeout(u64),
+}
+
+pub fn maybe_timeout(t: Term) -> NifResult<Option<Duration>> {
+    match t.decode()? {
+        Timeout::Infinity(_) => Ok(None),
+        Timeout::Timeout(ms) => Ok(Some(Duration::from_millis(ms))),
+    }
+}

--- a/rebar.config
+++ b/rebar.config
@@ -8,3 +8,5 @@
 {profiles, [{test, [{deps, [ {jsx, "3.1.0"}
                            , {erlexec, "1.18.11"}
                            ]}]}]}.
+
+{shell, [{apps, [erqwest]}]}.

--- a/src/erqwest.app.src
+++ b/src/erqwest.app.src
@@ -2,6 +2,7 @@
  [{description, "An erlang HTTP client wrapping reqwest"},
   {vsn, "0.0.2"},
   {registered, []},
+  {mod, {erqwest_app, []}},
   {applications,
    [kernel,
     stdlib

--- a/src/erqwest.erl
+++ b/src/erqwest.erl
@@ -2,6 +2,8 @@
 
 -export([ make_client/0
         , make_client/1
+        , start_runtime/1
+        , stop_runtime/1
         , close_client/1
         , start_client/1
         , start_client/2
@@ -72,7 +74,15 @@ make_client() ->
   make_client(#{}).
 
 -spec make_client(client_opts()) -> client().
-make_client(_Opts) ->
+make_client(Opts) ->
+  make_client(erqwest_runtime:get(), Opts).
+
+%% @private
+start_runtime(_Pid) ->
+  erlang:nif_error(nif_not_loaded).
+
+%% @private
+stop_runtime(_Runtime) ->
   erlang:nif_error(nif_not_loaded).
 
 %% @doc Close a client and idle connections in its pool. Returns immediately,
@@ -163,6 +173,9 @@ post(Client, Url, Opts) ->
 init() ->
   Nif = filename:join([code:priv_dir(erqwest), "liberqwest"]),
   ok = erlang:load_nif(Nif, 0).
+
+make_client(_Runtime, _Opts) ->
+  erlang:nif_error(nif_not_loaded).
 
 req_async_internal(_Client, _Pid, _Ref, _Req) ->
   erlang:nif_error(nif_not_loaded).

--- a/src/erqwest_app.erl
+++ b/src/erqwest_app.erl
@@ -1,0 +1,12 @@
+%% @private
+-module(erqwest_app).
+
+-behaviour(application).
+
+-export([start/2, stop/1]).
+
+start(_StartType, _StartArgs) ->
+    erqwest_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/src/erqwest_runtime.erl
+++ b/src/erqwest_runtime.erl
@@ -1,0 +1,53 @@
+%% @private
+%%
+%% This gen_server monitors the tokio runtime so that its failure can be handled
+%% by the supervision tree (for example in the case of a panic). Since this is
+%% not expected to happen, the reference to the runtime is stored in a
+%% persistent_term for efficiency.
+
+-module(erqwest_runtime).
+
+-behaviour(gen_server).
+
+-export([start_link/0, get/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2]).
+
+-record(state, {runtime}).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+  gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+get() ->
+  persistent_term:get(?MODULE).
+
+%% gen_server implementation
+
+init([]) ->
+  process_flag(trap_exit, true),
+  Runtime = erqwest:start_runtime(self()),
+  persistent_term:put(?MODULE, Runtime),
+  {ok, #state{runtime=Runtime}}.
+
+handle_call(_Request, _From, State) ->
+  {reply, ok, State}.
+
+handle_cast(_Request, State) ->
+  {noreply, State}.
+
+handle_info(erqwest_runtime_stopped, State) ->
+  {stop, erqwest_runtime_failure, State#state{runtime=undefined}};
+handle_info(_Info, State) ->
+  {noreply, State}.
+
+terminate(_Reason, #state{runtime=undefined}) ->
+  ok;
+terminate(_Reason, #state{runtime=Runtime}) ->
+  erqwest:stop_runtime(Runtime),
+  receive
+    erqwest_runtime_stopped -> ok
+  end.

--- a/src/erqwest_sup.erl
+++ b/src/erqwest_sup.erl
@@ -1,0 +1,20 @@
+%% @private
+-module(erqwest_sup).
+
+-behaviour(supervisor).
+
+-export([start_link/0]).
+
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+init([]) ->
+    SupFlags = #{strategy => one_for_all},
+    ChildSpecs = [#{ id => erqwest_runtime
+                   , start => {erqwest_runtime, start_link, []}
+                   }],
+    {ok, {SupFlags, ChildSpecs}}.


### PR DESCRIPTION
closes #1.

`Future::catch_unwind` seems to be unnecessary, since implementing `Drop` on `ErqwestResponse` has the same effect of ensuring a reply is always sent (even after a panic). The tokio `Runtime` seems to catch the panic. It does print a message to stderr though which might not be great.

I don't know if a tokio runtime _can_ panic under normal conditions, but if it did it would be really bad, so this also handles that by using a `gen_server` to monitor it. It also solves the problem of how to shut down the runtime correctly.